### PR TITLE
update readme based on declarative-project-mode

### DIFF
--- a/README.org
+++ b/README.org
@@ -10,9 +10,9 @@ any changes in the side-buffer.
 
 This package is intended for use in conjunction with the [[https://github.com/cuttlefisch/declarative-project-mode][declarative project mode
 package]], which allows users to specify their project contents and associated workspaces
-in a simple declarative .project file. See that project for example project specification.
+in a simple declarative PROJECT.yaml file. See that project for example project specification.
 Enabling treemacs-declarative-workspaces-mode will result in updates to the desired state
-when installing workspaces specified in the .project file.
+when installing workspaces specified in the PROJECT.yaml file.
 
 Please note that this package is currently in experimental stages, and as such may contain
 bugs or have limited functionality. We welcome any feedback or contributions to improve

--- a/treemacs-declarative-workspaces-mode.el
+++ b/treemacs-declarative-workspaces-mode.el
@@ -185,7 +185,7 @@ treemacs-declarative-workspaces--desired-state."
 (define-minor-mode treemacs-declarative-workspaces-mode
   "Manage treemacs workspaces via distrubuted declarative files.
 
-This package allows users to place `.project' files anywhere across
+This package allows users to place `PROJECT.yaml' files anywhere across
 the fileystem, and install them to treemacs workspaces via the
 `declarative-project-mode' package. The desired state of workspaces
 is then tracked via a central cache inside `user-emacs-directory'.


### PR DESCRIPTION
Update README to use the new project file name `PROJECT.yaml` in accordance with the recent update to declarative-project-mode.